### PR TITLE
Add camera entitlement

### DIFF
--- a/SimplyFinder/SimplyFinder/SimplyFinder.entitlements
+++ b/SimplyFinder/SimplyFinder/SimplyFinder.entitlements
@@ -14,9 +14,11 @@
 	<array>
 		<string>CloudKit</string>
 	</array>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
-	<true/>
+        <key>com.apple.security.app-sandbox</key>
+        <true/>
+        <key>com.apple.security.device.camera</key>
+        <true/>
+        <key>com.apple.security.files.user-selected.read-only</key>
+        <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- update entitlements to include camera access on macOS

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687292a59df4832281c5579229e646b8