### PR TITLE
Fix document picker file access

### DIFF
--- a/SimplyFinder/SimplyFinder/ContentView.swift
+++ b/SimplyFinder/SimplyFinder/ContentView.swift
@@ -778,7 +778,13 @@ struct DocumentPicker: UIViewControllerRepresentable {
         let parent: DocumentPicker
         init(_ parent: DocumentPicker) { self.parent = parent }
         func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
-            if let url = urls.first { parent.onPick(url) }
+            guard let url = urls.first else { return }
+            if url.startAccessingSecurityScopedResource() {
+                parent.onPick(url)
+                url.stopAccessingSecurityScopedResource()
+            } else {
+                parent.onPick(url)
+            }
         }
     }
 }
@@ -790,7 +796,13 @@ struct DocumentPicker: View {
         EmptyView()
             .fileImporter(isPresented: $show, allowedContentTypes: [.content, .item]) { result in
                 switch result {
-                case .success(let url): onPick(url)
+                case .success(let url):
+                    if url.startAccessingSecurityScopedResource() {
+                        onPick(url)
+                        url.stopAccessingSecurityScopedResource()
+                    } else {
+                        onPick(url)
+                    }
                 default: break
                 }
             }


### PR DESCRIPTION
## Summary
- enable security scoped resource handling when picking documents

## Testing
- `swiftc -o /tmp/test SimplyFinder/SimplyFinder/ContentView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68729996c9a08322af0f11ed398502cd