### PR TITLE
Add QuickLook preview for documents

### DIFF
--- a/SimplyFinder/SimplyFinder/QuickLookPreview.swift
+++ b/SimplyFinder/SimplyFinder/QuickLookPreview.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+import QuickLook
+
+#if os(iOS)
+struct QuickLookPreview: UIViewControllerRepresentable {
+    var url: URL
+
+    func makeCoordinator() -> Coordinator { Coordinator(url: url) }
+
+    func makeUIViewController(context: Context) -> QLPreviewController {
+        let controller = QLPreviewController()
+        controller.dataSource = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ controller: QLPreviewController, context: Context) {
+        context.coordinator.url = url
+        controller.reloadData()
+    }
+
+    class Coordinator: NSObject, QLPreviewControllerDataSource {
+        var url: URL
+        init(url: URL) { self.url = url }
+        func numberOfPreviewItems(in controller: QLPreviewController) -> Int { 1 }
+        func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem {
+            url as NSURL
+        }
+    }
+}
+#else
+struct QuickLookPreview: NSViewRepresentable {
+    var url: URL
+
+    func makeNSView(context: Context) -> QLPreviewView {
+        let view = QLPreviewView()
+        view.autostarts = true
+        view.previewItem = url as NSURL
+        return view
+    }
+
+    func updateNSView(_ nsView: QLPreviewView, context: Context) {
+        nsView.previewItem = url as NSURL
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- preview non-image files using QuickLook
- generate a temporary preview file when needed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872e17ca2748322ae38b8d7852a5efc