### PR TITLE
Fix macOS document picker availability

### DIFF
--- a/SimplyFinder/SimplyFinder/ContentView.swift
+++ b/SimplyFinder/SimplyFinder/ContentView.swift
@@ -13,7 +13,9 @@ typealias PlatformImage = NSImage
 // MARK: - ItemType Enum
 
 enum ItemType: Int16, CaseIterable, Identifiable {
-    case text, photo, camera, video, document
+    case text, photo, camera, video
+    @available(macOS, unavailable, message: "Document picker not available on macOS")
+    case document
     var id: Int16 { rawValue }
     var label: String { ["Text", "Photo", "Camera", "Video", "Document"][Int(rawValue)] }
     var icon: String { ["character.cursor.ibeam", "photo", "camera", "video", "doc"][Int(rawValue)] }


### PR DESCRIPTION
## Summary
- mark the document item type as unavailable on macOS

## Testing
- `swiftc -emit-sil -O SimplyFinder/SimplyFinder/ContentView.swift -o /tmp/out.sil` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6872f14ed0048322a5b51d8eca140b79