### PR TITLE
Fix rename sheet state cleanup

### DIFF
--- a/SimplyFinder/SimplyFinder/ContentView.swift
+++ b/SimplyFinder/SimplyFinder/ContentView.swift
@@ -246,11 +246,15 @@ struct ContentView: View {
                     }
                     .navigationTitle("Rename Folder")
                     .navigationBarItems(
-                        leading: Button("Cancel") { renameFolder = nil },
+                        leading: Button("Cancel") {
+                            renameFolder = nil
+                            renameFolderName = ""
+                        },
                         trailing: Button("Save") {
                             folder.name = renameFolderName
                             CoreDataStack.shared.save()
                             renameFolder = nil
+                            renameFolderName = ""
                         }.disabled(renameFolderName.trimmingCharacters(in: .whitespaces).isEmpty)
                     )
                 }


### PR DESCRIPTION
## Summary
- reset `renameFolderName` when dismissing rename sheet
- parsed the swift files with `swiftc -parse` to ensure no syntax errors

## Testing
- `swiftc -parse SimplyFinder/SimplyFinder/ContentView.swift && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_6872f1de02b88322a7f275eaabc96cc1