### PR TITLE
Fix camera layout on iPad

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Open `SimplyFinder/SimplyFinder.xcodeproj` in Xcode and run the `SimplyFinder` s
 
 Document picking is only supported on iOS. On iPhone, imported documents now save both their name and data so you can view them later without reimporting.
 
+## iPad Support
+The interface adapts to iPad screens. When using the camera, the picker now presents in full‑screen mode on iPad to avoid the view being clipped.
+
 ## Troubleshooting
 When running in a sandboxed environment you may see log output similar to:
 

--- a/SimplyFinder/SimplyFinder/ContentView.swift
+++ b/SimplyFinder/SimplyFinder/ContentView.swift
@@ -766,6 +766,9 @@ struct CameraView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIImagePickerController {
         let picker = UIImagePickerController()
         picker.delegate = context.coordinator
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            picker.modalPresentationStyle = .fullScreen
+        }
         if mediaType == .photo {
             picker.sourceType = .camera
             picker.mediaTypes = ["public.image"]


### PR DESCRIPTION
## Summary
- ensure `UIImagePickerController` uses full-screen presentation on iPad
- document new iPad behavior in the README

## Testing
- `swift --version`
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68758feee0308322be8fa1a8fc77b90b